### PR TITLE
Nerfs Ion cannons costing half a bar of gold/makes them do the thing …

### DIFF
--- a/code/controllers/subsystem/ships.dm
+++ b/code/controllers/subsystem/ships.dm
@@ -236,7 +236,7 @@ SUBSYSTEM_DEF(ship)
 		C.health = max(C.health - attack_data.hull_damage, 0)
 		if(attack_data.unique_effect)
 			if(attack_data.unique_effect & ION_BOARDING_BOOST) //boosts boarding chance if they use an ion cannon
-				if(!S.boarding_chance) //Prevents giving ships without boarding maps the buff
+				if(S.boarding_chance) //Prevents giving ships without boarding maps the buff
 					S.boarding_chance += 5
 		if(C.health <= 0)
 			if(C.active)

--- a/code/modules/research/designs/ship_weaponry.dm
+++ b/code/modules/research/designs/ship_weaponry.dm
@@ -5,6 +5,6 @@
   desc = "Allows for the construction of an Ion cannon's main circuitry."
   id = "ion_cannon_board"
   req_tech = list("programming" = 4, "powerstorage" = 4, "combat" = 4, "engineering" = 3)
-  materials = list(MAT_GLASS = 2000, MAT_GOLD = 1000) //all on the aer at roundstart
+  materials = list(MAT_GLASS = 2000, MAT_GOLD = 10000) //all on the aer at roundstart
   build_path = /obj/item/weapon/circuitboard/machine/ion_cannon
   category = list("Ship Weaponry")


### PR DESCRIPTION
…they are supposed to do in the first place (#3478)

* Nerfs Ion cannons costing half a bar

* Actually makes the ion cannons boost boarding chance

[Changelogs]: # (Please make a changelog if you're adding, removing or changing content that'll affect players. This includes, but is not limited to, new features, sprites, sounds; balance changes; map edits and important fixes)
[]: # (See here for how to easily make a changelog: https://github.com/tgstation/tgstation/wiki/Changelogs. An example changelog has been provided below. Please edit or remove)


:cl: optional name here
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
wip: added a few works in progress
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
experiment: added an experimental thingy
/:cl:

[why]: # (Please add a short description [on the next line] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:) 
